### PR TITLE
Outdated YAML

### DIFF
--- a/bbpipe/main.py
+++ b/bbpipe/main.py
@@ -26,7 +26,7 @@ def run(pipeline_config_filename, dry_run=False, pycmd='python3'):
     init_time_ms = int(time.time()*1e3)
 
     # YAML input file.
-    pipe_config = yaml.load(open(pipeline_config_filename))
+    pipe_config = yaml.safe_load(open(pipeline_config_filename))
     output_dir = pipe_config['output_dir']
     os.makedirs(output_dir, exist_ok=True)
 
@@ -88,7 +88,7 @@ def export_cwl(args):
     """
     path = args.export_cwl
     # YAML input file.
-    config = yaml.load(open(args.pipeline_config))
+    config = yaml.safe_load(open(args.pipeline_config))
 
     # Python modules in which to search for pipeline stages
     modules = config['modules'].split()

--- a/bbpipe/stage.py
+++ b/bbpipe/stage.py
@@ -204,7 +204,7 @@ Missing these names on the command line:
 
         # This is all the config information in the file, including
         # things for other stages
-        overall_config = yaml.load(open(self.get_input('config')))
+        overall_config = yaml.safe_load(open(self.get_input('config')))
         
         # The user can define global options that are inherited by
         # all the other sections if not already specified there.

--- a/bbpipe/stage.py
+++ b/bbpipe/stage.py
@@ -311,7 +311,7 @@ Missing these names on the command line:
             else:
                 param_type=type_dict[def_val] if type(def_val) == type else type_dict[type(def_val)]
                 default=def_val if type(def_val) != type else None
-                if param_type is 'boolean':
+                if param_type == 'boolean':
                     input_binding = cwlgen.CommandLineBinding(prefix='--{}'.format(opt))
                 else:
                     input_binding = cwlgen.CommandLineBinding(prefix='--{}='.format(opt), separate=False)


### PR DESCRIPTION
Newer versions of yaml would fail because we are using `load` instead of `safe_load`. This fixes that.