### PR TITLE
Upldate README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ python setup.py install
 
 Once installed, you can test the installation by running it on the current [test power-spectrum pipeline](bbpower_test) (mostly made out of placeholders). To do so, type:
 ```bash
-bbpipe test/test.yml
+bbpipe test/test_ini.yml
 ```
 
 ## Creating a pipeline

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@ Building Beautiful pipelines - A pipeline constructor
 ----------------------------
 A framework for creating pipelines for the Simons Observatory. Documentation is still under development, but details about how to use this package to create new pipelines can be found below and in [CONTRIBUTING.md](CONTRIBUTING.md). 
 
+## Dependencies
+- python<=3.9.x
+- numpy
+- healpy
+- ipython_genutils
+- pyyaml
+- parsl<0.6.0
+
 ## Installation
 To install `BBPipe`, just clone this repository and run
 ```bash


### PR DESCRIPTION
- Update test pipline document
- Add dependency list. `parsl<0.6.0` specified in [setup.py](https://github.com/simonsobs/BBPipe/blob/dd84b6ec664c191aaed369212cd60f6e5302ba36/setup.py#L26) does not work with `python>=3.10` on my side, so capped at `3.9.x`.